### PR TITLE
make encoding configurable and make Projector class closeable

### DIFF
--- a/pypjlink/cli.py
+++ b/pypjlink/cli.py
@@ -88,6 +88,7 @@ def cmd_errors(p):
 def make_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument('-p', '--projector')
+    parser.add_argument('-e', '--encoding', default='utf-8')
 
     sub = parser.add_subparsers(dest='command', title='command')
     sub.required = True
@@ -161,17 +162,18 @@ def main():
 
     projector = kwargs.pop('projector')
     host, port, password = resolve_projector(projector)
+    encoding = kwargs.pop('encoding')
 
     if not password:
         password = getpass
 
-    proj = Projector.from_address(host, port)
-    rv = proj.authenticate(password)
-    if rv is False:
-        print_error('Incorrect password.')
-        return
+    with Projector.from_address(host, port, encoding) as proj:
+        rv = proj.authenticate(password)
+        if rv is False:
+            print_error('Incorrect password.')
+            return
 
-    func(proj, **kwargs)
+        func(proj, **kwargs)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Some devices don't use `utf-8` for encoding which causes some commands to fails.

Added a `close()` method to the `Projector` class to release the resources allocated to an instance. Also added `__enter__` and `__exit__` method to be able to use python `with` statement.

```python
with Projector.from_address('projector_host') as projector:
    p.authenticate()
    p.set_power('off')
```