### PR TITLE
Add socket timeout

### DIFF
--- a/pypjlink/projector.py
+++ b/pypjlink/projector.py
@@ -60,9 +60,10 @@ class Projector(object):
         self.f.close()
 
     @classmethod
-    def from_address(cls, address, port=4352, encoding='utf-8'):
+    def from_address(cls, address, port=4352, encoding='utf-8', timeout=3):
         """build a Projector from a ip address"""
         sock = socket.socket()
+        sock.settimeout(timeout)
         sock.connect((address, port))
         # in python 3 I need to specify newline, otherwise read hangs
         # in "PJLINK 0\r"


### PR DESCRIPTION
Sometimes a projector fails to repsonse, and pypjlink may wait
indefinitely, this causes the state to not update in homeassitant.

This commit adds a socket timeout so the socket will throw an
exception and the connection can be retried.