### PR TITLE
Update protocol.py to strip white spaces from body - Mitsubishi projector bug

### DIFF
--- a/pypjlink/protocol.py
+++ b/pypjlink/protocol.py
@@ -43,6 +43,7 @@ def parse_response(f, encoding, data=''):
     assert sep == '='
 
     param = read_until(f, '\r', encoding)
+    param.lstrip()
 
     return (body, param)
 


### PR DESCRIPTION
Some projectors have a bug where white spaces are inserted in some responses prior to data.

e.g Mitsubishi 3D HC7800D for command "inst ?" responds "%1INST= 11 23 31 34"


This updatestrips the leading whitespace